### PR TITLE
compliance with panda dataframe

### DIFF
--- a/nbautoeval/exercise_function.py
+++ b/nbautoeval/exercise_function.py
@@ -332,7 +332,7 @@ class ExerciseFunction:                                           # pylint: disa
 
         if DEBUG:
             print(f"ExerciseFunction.validate is comparing {expected} with {result}")
-        if isinstance(expected, pd.DataFrame):
+        if isinstance(expected, (pd.DataFrame, pd.Series)):
             return expected.equals(result)
         else:
             return expected == result

--- a/nbautoeval/exercise_function.py
+++ b/nbautoeval/exercise_function.py
@@ -12,6 +12,7 @@ from .callrenderer import Call, CallRenderer
 from .renderer import Renderer
 from .helpers import default_font_size, default_header_font_size
 from .storage import log_correction, log2_correction
+import pandas as pd
 
 
 DEBUG = False
@@ -331,8 +332,10 @@ class ExerciseFunction:                                           # pylint: disa
 
         if DEBUG:
             print(f"ExerciseFunction.validate is comparing {expected} with {result}")
-
-        return expected == result
+        if isinstance(expected, pd.DataFrame):
+            return expected.equals(result)
+        else:
+            return expected == result
 
 # see this question on SO
 # https://stackoverflow.com/questions/40659212/futurewarning-elementwise-comparison-failed-returning-scalar-but-in-the-futur


### PR DESCRIPTION
prevent exercise_function from failing when comparing panda dataframe.
The display is still bad/confusing, but at least it does work now.
![image](https://user-images.githubusercontent.com/11618427/102493989-48669b00-4074-11eb-8d7d-01d0c50c766c.png)

Partially fix #34 
